### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+      
+      - name: Build and verify with Maven
+        run: mvn clean verify


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs `mvn clean verify` on pull requests and pushes to the main branch.

## Changes
- Created `.github/workflows/ci.yml` with CI configuration
- Configured to run on Java 25 with Temurin distribution
- Uses latest GitHub Actions versions:
  - `actions/checkout@v4`
  - `actions/setup-java@v5`
- Enabled Maven caching for faster builds

The workflow will automatically build and verify the Jenkins plugin on every PR and push to main.