### PR TITLE
Add global configuration for output directory and max dumps

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfr/DefaultJfrService.java
+++ b/src/main/java/io/jenkins/plugins/jfr/DefaultJfrService.java
@@ -4,10 +4,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import org.jspecify.annotations.NonNull;
@@ -29,8 +31,11 @@ class DefaultJfrService implements JfrService {
                 .filter(r -> r.getName().equals(request.name()))
                 .findFirst();
         if (recording.isPresent()) {
-            Path path = Files.createTempFile("jenkins-jvm-", ".jfr");
+            Path outputDir = resolveOutputDirectory();
+            Files.createDirectories(outputDir);
+            Path path = Files.createTempFile(outputDir, "jenkins-jvm-", ".jfr");
             recording.get().dump(path);
+            enforceMaxDumps(outputDir);
             return new DumpResponse(path.toString());
         }
         throw new NoSuchElementException("Recording not found");
@@ -43,6 +48,36 @@ class DefaultJfrService implements JfrService {
         recording.setDuration(Duration.ofSeconds(request.durationInSeconds()));
         recording.start();
         return toJfrSession(recording);
+    }
+
+    @NonNull
+    private static Path resolveOutputDirectory() {
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+        String outputDirectory = config.getOutputDirectory();
+        if (outputDirectory != null && !outputDirectory.isBlank()) {
+            return Path.of(outputDirectory);
+        }
+        return Path.of(System.getProperty("java.io.tmpdir"));
+    }
+
+    private static void enforceMaxDumps(@NonNull Path outputDir) throws IOException {
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+        int maxDumps = config.getMaxDumps();
+        try (Stream<Path> files = Files.list(outputDir)) {
+            List<Path> jfrFiles = files.filter(p -> p.toString().endsWith(".jfr"))
+                    .filter(p -> p.getFileName().toString().startsWith("jenkins-jvm-"))
+                    .sorted(Comparator.comparingLong(p -> {
+                        try {
+                            return Files.getLastModifiedTime(p).toMillis();
+                        } catch (IOException e) {
+                            return 0L;
+                        }
+                    }))
+                    .collect(Collectors.toList());
+            while (jfrFiles.size() > maxDumps) {
+                Files.deleteIfExists(jfrFiles.remove(0));
+            }
+        }
     }
 
     @NonNull

--- a/src/main/java/io/jenkins/plugins/jfr/DefaultJfrService.java
+++ b/src/main/java/io/jenkins/plugins/jfr/DefaultJfrService.java
@@ -13,8 +13,12 @@ import java.util.stream.Stream;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DefaultJfrService implements JfrService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultJfrService.class);
 
     @Override
     @NonNull
@@ -70,12 +74,17 @@ class DefaultJfrService implements JfrService {
                         try {
                             return Files.getLastModifiedTime(p).toMillis();
                         } catch (IOException e) {
+                            LOG.warn("Failed to read last modified time for {}", p, e);
                             return 0L;
                         }
                     }))
                     .collect(Collectors.toList());
             while (jfrFiles.size() > maxDumps) {
-                Files.deleteIfExists(jfrFiles.remove(0));
+                Path toDelete = jfrFiles.remove(0);
+                long size = Files.size(toDelete);
+                if (Files.deleteIfExists(toDelete)) {
+                    LOG.info("Deleted JFR dump {} ({} bytes)", toDelete, size);
+                }
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/jfr/DefaultJfrService.java
+++ b/src/main/java/io/jenkins/plugins/jfr/DefaultJfrService.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 class DefaultJfrService implements JfrService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultJfrService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultJfrService.class);
 
     @Override
     @NonNull
@@ -39,7 +39,11 @@ class DefaultJfrService implements JfrService {
             Files.createDirectories(outputDir);
             Path path = Files.createTempFile(outputDir, "jenkins-jvm-", ".jfr");
             recording.get().dump(path);
-            enforceMaxDumps(outputDir);
+            try {
+                enforceMaxDumps(outputDir);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to enforce max dumps in {}", outputDir, e);
+            }
             return new DumpResponse(path.toString());
         }
         throw new NoSuchElementException("Recording not found");
@@ -74,16 +78,20 @@ class DefaultJfrService implements JfrService {
                         try {
                             return Files.getLastModifiedTime(p).toMillis();
                         } catch (IOException e) {
-                            LOG.warn("Failed to read last modified time for {}", p, e);
-                            return 0L;
+                            LOGGER.warn("Failed to read last modified time for {}", p, e);
+                            return Long.MAX_VALUE;
                         }
                     }))
                     .collect(Collectors.toList());
             while (jfrFiles.size() > maxDumps) {
                 Path toDelete = jfrFiles.remove(0);
-                long size = Files.size(toDelete);
-                if (Files.deleteIfExists(toDelete)) {
-                    LOG.info("Deleted JFR dump {} ({} bytes)", toDelete, size);
+                try {
+                    long size = Files.size(toDelete);
+                    if (Files.deleteIfExists(toDelete)) {
+                        LOGGER.info("Deleted JFR dump {} ({} bytes)", toDelete, size);
+                    }
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to delete old JFR dump {}", toDelete, e);
                 }
             }
         }

--- a/src/main/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration.java
@@ -1,0 +1,84 @@
+package io.jenkins.plugins.jfr;
+
+import hudson.Extension;
+import hudson.util.FormValidation;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
+
+    private static final int DEFAULT_MAX_DUMPS = 10;
+
+    @Nullable
+    private String outputDirectory;
+
+    private int maxDumps = DEFAULT_MAX_DUMPS;
+
+    public JavaFlightRecorderConfiguration() {
+        load();
+    }
+
+    @NonNull
+    public static JavaFlightRecorderConfiguration get() {
+        return GlobalConfiguration.all().getInstance(JavaFlightRecorderConfiguration.class);
+    }
+
+    @Nullable
+    public String getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    @DataBoundSetter
+    public void setOutputDirectory(@Nullable String outputDirectory) {
+        this.outputDirectory = outputDirectory;
+        save();
+    }
+
+    public int getMaxDumps() {
+        return maxDumps;
+    }
+
+    @DataBoundSetter
+    public void setMaxDumps(int maxDumps) {
+        this.maxDumps = maxDumps;
+        save();
+    }
+
+    public FormValidation doCheckOutputDirectory(@QueryParameter String value) {
+        if (value == null || value.isBlank()) {
+            return FormValidation.ok("Default: system temporary directory");
+        }
+        java.nio.file.Path path = java.nio.file.Path.of(value);
+        if (!path.isAbsolute()) {
+            return FormValidation.error("Output directory must be an absolute path");
+        }
+        if (java.nio.file.Files.exists(path) && !java.nio.file.Files.isDirectory(path)) {
+            return FormValidation.error("Path exists but is not a directory");
+        }
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckMaxDumps(@QueryParameter String value) {
+        try {
+            int parsed = Integer.parseInt(value);
+            if (parsed < 1) {
+                return FormValidation.error("Must be at least 1");
+            }
+            return FormValidation.ok();
+        } catch (NumberFormatException e) {
+            return FormValidation.error("Must be a positive integer");
+        }
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 @Extension
 public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
@@ -38,7 +38,7 @@ public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
 
     @DataBoundSetter
     public void setOutputDirectory(@Nullable String outputDirectory) {
-        this.outputDirectory = outputDirectory;
+        this.outputDirectory = (outputDirectory == null || outputDirectory.isBlank()) ? null : outputDirectory;
         save();
     }
 
@@ -48,6 +48,9 @@ public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
 
     @DataBoundSetter
     public void setMaxDumps(int maxDumps) {
+        if (maxDumps < 1) {
+            throw new IllegalArgumentException("maxDumps must be at least 1");
+        }
         this.maxDumps = maxDumps;
         save();
     }
@@ -79,7 +82,7 @@ public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
         return true;
     }

--- a/src/main/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration.java
@@ -2,6 +2,8 @@ package io.jenkins.plugins.jfr;
 
 import hudson.Extension;
 import hudson.util.FormValidation;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.jspecify.annotations.NonNull;
@@ -13,7 +15,7 @@ import org.kohsuke.stapler.StaplerRequest;
 @Extension
 public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
 
-    private static final int DEFAULT_MAX_DUMPS = 10;
+    private static final int DEFAULT_MAX_DUMPS = 3;
 
     @Nullable
     private String outputDirectory;
@@ -54,11 +56,11 @@ public class JavaFlightRecorderConfiguration extends GlobalConfiguration {
         if (value == null || value.isBlank()) {
             return FormValidation.ok("Default: system temporary directory");
         }
-        java.nio.file.Path path = java.nio.file.Path.of(value);
+        Path path = Path.of(value);
         if (!path.isAbsolute()) {
             return FormValidation.error("Output directory must be an absolute path");
         }
-        if (java.nio.file.Files.exists(path) && !java.nio.file.Files.isDirectory(path)) {
+        if (Files.exists(path) && !Files.isDirectory(path)) {
             return FormValidation.error("Path exists but is not a directory");
         }
         return FormValidation.ok();

--- a/src/main/resources/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration/config.jelly
@@ -7,7 +7,7 @@
     </f:entry>
     <f:entry title="Maximum Dumps to Keep" field="maxDumps"
              description="Maximum number of JFR dump files to retain. Oldest files are removed first.">
-      <f:textbox default="10" />
+      <f:textbox default="3" />
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfr/JavaFlightRecorderConfiguration/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:section title="Java Flight Recorder">
+    <f:entry title="Output Directory" field="outputDirectory"
+             description="Absolute path for JFR dump files. Defaults to the system temporary directory if left blank.">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Maximum Dumps to Keep" field="maxDumps"
+             description="Maximum number of JFR dump files to retain. Oldest files are removed first.">
+      <f:textbox default="10" />
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/test/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfigurationTest.java
@@ -21,7 +21,7 @@ class JavaFlightRecorderConfigurationTest {
 
         // then
         assertThat(config.getOutputDirectory()).isNull();
-        assertThat(config.getMaxDumps()).isEqualTo(10);
+        assertThat(config.getMaxDumps()).isEqualTo(3);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfigurationTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.jfr;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import hudson.util.FormValidation;
 import java.io.IOException;
@@ -46,6 +47,36 @@ class JavaFlightRecorderConfigurationTest {
 
         // then
         assertThat(config.getMaxDumps()).isEqualTo(5);
+    }
+
+    @Test
+    void setMaxDumpsRejectsZero(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // then
+        assertThatThrownBy(() -> config.setMaxDumps(0)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void setMaxDumpsRejectsNegative(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // then
+        assertThatThrownBy(() -> config.setMaxDumps(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void setOutputDirectoryNormalizesBlankToNull(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        config.setOutputDirectory("  ");
+
+        // then
+        assertThat(config.getOutputDirectory()).isNull();
     }
 
     @Test
@@ -150,7 +181,7 @@ class JavaFlightRecorderConfigurationTest {
         // given
         JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
         config.setOutputDirectory("/tmp/jfr-test");
-        config.setMaxDumps(3);
+        config.setMaxDumps(7);
 
         // when
         r.configRoundtrip();
@@ -158,6 +189,6 @@ class JavaFlightRecorderConfigurationTest {
         // then
         JavaFlightRecorderConfiguration reloaded = JavaFlightRecorderConfiguration.get();
         assertThat(reloaded.getOutputDirectory()).isEqualTo("/tmp/jfr-test");
-        assertThat(reloaded.getMaxDumps()).isEqualTo(3);
+        assertThat(reloaded.getMaxDumps()).isEqualTo(7);
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/jfr/JavaFlightRecorderConfigurationTest.java
@@ -1,0 +1,163 @@
+package io.jenkins.plugins.jfr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import hudson.util.FormValidation;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class JavaFlightRecorderConfigurationTest {
+
+    @Test
+    void defaultValues(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // then
+        assertThat(config.getOutputDirectory()).isNull();
+        assertThat(config.getMaxDumps()).isEqualTo(10);
+    }
+
+    @Test
+    void setAndGetOutputDirectory(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        config.setOutputDirectory("/tmp/jfr-dumps");
+
+        // then
+        assertThat(config.getOutputDirectory()).isEqualTo("/tmp/jfr-dumps");
+    }
+
+    @Test
+    void setAndGetMaxDumps(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        config.setMaxDumps(5);
+
+        // then
+        assertThat(config.getMaxDumps()).isEqualTo(5);
+    }
+
+    @Test
+    void doCheckOutputDirectoryAcceptsBlank(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckOutputDirectory("");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.OK);
+    }
+
+    @Test
+    void doCheckOutputDirectoryAcceptsAbsolutePath(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckOutputDirectory("/tmp/jfr-output");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.OK);
+    }
+
+    @Test
+    void doCheckOutputDirectoryRejectsRelativePath(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckOutputDirectory("relative/path");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.ERROR);
+    }
+
+    @Test
+    void doCheckOutputDirectoryRejectsFileAsPath(JenkinsRule r, @TempDir Path tempDir) throws IOException {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+        Path file = Files.createFile(tempDir.resolve("not-a-dir"));
+
+        // when
+        FormValidation result = config.doCheckOutputDirectory(file.toString());
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.ERROR);
+    }
+
+    @Test
+    void doCheckMaxDumpsAcceptsPositiveInteger(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckMaxDumps("5");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.OK);
+    }
+
+    @Test
+    void doCheckMaxDumpsRejectsZero(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckMaxDumps("0");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.ERROR);
+    }
+
+    @Test
+    void doCheckMaxDumpsRejectsNegative(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckMaxDumps("-1");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.ERROR);
+    }
+
+    @Test
+    void doCheckMaxDumpsRejectsNonNumeric(JenkinsRule r) {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+
+        // when
+        FormValidation result = config.doCheckMaxDumps("abc");
+
+        // then
+        assertThat(result.kind).isEqualTo(FormValidation.Kind.ERROR);
+    }
+
+    @Test
+    void configurationSurvivesRoundTrip(JenkinsRule r) throws Exception {
+        // given
+        JavaFlightRecorderConfiguration config = JavaFlightRecorderConfiguration.get();
+        config.setOutputDirectory("/tmp/jfr-test");
+        config.setMaxDumps(3);
+
+        // when
+        r.configRoundtrip();
+
+        // then
+        JavaFlightRecorderConfiguration reloaded = JavaFlightRecorderConfiguration.get();
+        assertThat(reloaded.getOutputDirectory()).isEqualTo("/tmp/jfr-test");
+        assertThat(reloaded.getMaxDumps()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
Closes #26

Adds a Jenkins GlobalConfiguration page for the Java Flight Recorder plugin with two settings:

- **Output Directory** — absolute path where JFR dump files are written. Falls back to the system temp directory when blank.
- **Maximum Dumps to Keep** — caps the number of `jenkins-jvm-*.jfr` files in the output directory, removing oldest first. Defaults to 10.

### Changes

- `JavaFlightRecorderConfiguration` — new `GlobalConfiguration` extension with form validation for both fields
- `config.jelly` — global config UI
- `DefaultJfrService.dump()` — uses configured output directory and enforces the max dumps limit after each dump
- 12 new tests covering defaults, setters, validation (absolute path, non-directory, positive integer), and a `configRoundtrip` persistence test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Java Flight Recorder settings: configure output directory for JFR dumps and set maximum dumps to retain.
  * JFR dumps are written to the configured location (or system temp if unset) with automatic pruning of oldest dumps when the limit is exceeded.

* **Tests**
  * Add tests covering configuration defaults, validation, persistence, and pruning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->